### PR TITLE
Fix spacing issue on Information tab

### DIFF
--- a/tuberculosis/lib/pages/information_tab_page.dart
+++ b/tuberculosis/lib/pages/information_tab_page.dart
@@ -72,8 +72,7 @@ class VideoScreen extends StatelessWidget {
           middle: new Text(_topic),
         ),
         child: new Material(
-            child: new Padding(
-                padding: MediaQuery.of(context).padding * 2.0,
+            child: new SafeArea(
                 child: new GridView.count(
                     primary: false,
                     padding: const EdgeInsets.all(20.0),


### PR DESCRIPTION
- added a SafeArea to dynamically account for padding

This fixes the issue where the space between the NavigationBar and GridView would be different per device (e.g. iPhone X vs. iPhone 8).

See also: https://docs.flutter.io/flutter/widgets/SafeArea-class.html