### PR TITLE
Fix calendar issues

### DIFF
--- a/tuberculosis/lib/calendar/calendar.dart
+++ b/tuberculosis/lib/calendar/calendar.dart
@@ -199,6 +199,8 @@ class CalendarState extends State<Calendar> {
       updateSelectedRange(firstDateOfNewMonth, lastDateOfNewMonth);
       selectedMonthsDays = Utils.daysInMonth(today);
       displayMonth = Utils.formatMonth(today);
+      _selectedDate = today;
+      widget?.onDateSelected(_selectedDate);
     });
   }
 

--- a/tuberculosis/lib/calendar/date_utils.dart
+++ b/tuberculosis/lib/calendar/date_utils.dart
@@ -16,23 +16,23 @@ class Utils {
   static String apiDayFormat(DateTime d) => _apiDayFormat.format(d);
 
   static const List<String> weekdays = const [
-    "S",
     "M",
     "T",
     "W",
     "T",
     "F",
+    "S",
     "S"
   ];
 
   /// The list of days in a given month
   static List<DateTime> daysInMonth(DateTime month) {
     var first = firstDayOfMonth(month);
-    var daysBefore = first.weekday;
+    // Account for week starting on Sunday.
+    var daysBefore = first.weekday - 1;
     var firstToDisplay = first.subtract(new Duration(days: daysBefore));
     var last = Utils.lastDayOfMonth(month);
-
-    var daysAfter = 7 - last.weekday;
+    var daysAfter = 7 - last.weekday + 1;
     var lastToDisplay = last.add(new Duration(days: daysAfter));
     return daysInRange(firstToDisplay, lastToDisplay).toList();
   }


### PR DESCRIPTION
- resolve issue in calendar where dates are off-by-one
- change calendar such that weeks start on Monday rather than Sunday
- resolve issue where the today button would not correctly select the current day

This resolves issue #31.