### PR TITLE
Fix issue in calendar date picker

### DIFF
--- a/tuberculosis/lib/calendar/calendar.dart
+++ b/tuberculosis/lib/calendar/calendar.dart
@@ -199,8 +199,7 @@ class CalendarState extends State<Calendar> {
       updateSelectedRange(firstDateOfNewMonth, lastDateOfNewMonth);
       selectedMonthsDays = Utils.daysInMonth(today);
       displayMonth = Utils.formatMonth(today);
-      _selectedDate = today;
-      widget.onDateSelected(_selectedDate);
+      _setDateToday(today);
     });
   }
 
@@ -246,8 +245,7 @@ class CalendarState extends State<Calendar> {
       var lastDayOfCurrentWeek = Utils.lastDayOfWeek(selected);
 
       setState(() {
-        _selectedDate = selected;
-        widget.onDateSelected(_selectedDate);
+        _setDateToday(selected);
         selectedWeeksDays = Utils
             .daysInRange(firstDayOfCurrentWeek, lastDayOfCurrentWeek)
             .toList();
@@ -291,5 +289,10 @@ class CalendarState extends State<Calendar> {
     if (widget.onDateSelected != null) {
       widget.onDateSelected(day);
     }
+  }
+
+  void _setDateToday(DateTime date) {
+    _selectedDate = date;
+    widget.onDateSelected(date);
   }
 }

--- a/tuberculosis/lib/calendar/calendar.dart
+++ b/tuberculosis/lib/calendar/calendar.dart
@@ -200,7 +200,7 @@ class CalendarState extends State<Calendar> {
       selectedMonthsDays = Utils.daysInMonth(today);
       displayMonth = Utils.formatMonth(today);
       _selectedDate = today;
-      widget?.onDateSelected(_selectedDate);
+      widget.onDateSelected(_selectedDate);
     });
   }
 
@@ -247,6 +247,7 @@ class CalendarState extends State<Calendar> {
 
       setState(() {
         _selectedDate = selected;
+        widget.onDateSelected(_selectedDate);
         selectedWeeksDays = Utils
             .daysInRange(firstDayOfCurrentWeek, lastDayOfCurrentWeek)
             .toList();

--- a/tuberculosis/lib/main.dart
+++ b/tuberculosis/lib/main.dart
@@ -17,7 +17,7 @@ class MyApp extends StatefulWidget {
 
 class _MyAppState extends State<MyApp> {
   DateTime selectedDate;
-  bool _userLoggedIn = true; // replace with actual check in the future.
+  bool _userLoggedIn = false; // replace with actual check in the future.
 
   _MyAppState() : selectedDate = new DateTime.now();
 


### PR DESCRIPTION
This fixes an issue in the calendar date picker where a newly selected
date would not trigger a rebuild in the medicine tab, due to a missing
call to setState.