### PR TITLE
Rename method for clarity

### DIFF
--- a/tuberculosis/lib/calendar/calendar.dart
+++ b/tuberculosis/lib/calendar/calendar.dart
@@ -199,7 +199,7 @@ class CalendarState extends State<Calendar> {
       updateSelectedRange(firstDateOfNewMonth, lastDateOfNewMonth);
       selectedMonthsDays = Utils.daysInMonth(today);
       displayMonth = Utils.formatMonth(today);
-      _setDateToday(today);
+      _setDateSelected(today);
     });
   }
 
@@ -245,7 +245,7 @@ class CalendarState extends State<Calendar> {
       var lastDayOfCurrentWeek = Utils.lastDayOfWeek(selected);
 
       setState(() {
-        _setDateToday(selected);
+        _setDateSelected(selected);
         selectedWeeksDays = Utils
             .daysInRange(firstDayOfCurrentWeek, lastDayOfCurrentWeek)
             .toList();
@@ -291,7 +291,7 @@ class CalendarState extends State<Calendar> {
     }
   }
 
-  void _setDateToday(DateTime date) {
+  void _setDateSelected(DateTime date) {
     _selectedDate = date;
     widget.onDateSelected(date);
   }


### PR DESCRIPTION
`_setDateToday` is not named properly. We're setting the selected date, which need not be today.
Renamed to `_setDateSelected`.