### PR TITLE
Implement selected day's meds on calendar page

### DIFF
--- a/tuberculosis/lib/calendar/calendar.dart
+++ b/tuberculosis/lib/calendar/calendar.dart
@@ -187,7 +187,7 @@ class CalendarState extends State<Calendar> {
   Widget build(BuildContext context) {
     final mediaQuery = MediaQuery.of(context);
     return new Padding(
-        child: new Column(children: [nameAndIconRow, calendarGridView]),
+        child: new Column(children: [nameAndIconRow, calendarGridView], mainAxisSize: MainAxisSize.max, mainAxisAlignment: MainAxisAlignment.start,),
         padding: new EdgeInsets.only(top: mediaQuery.padding.top));
   }
 

--- a/tuberculosis/lib/calendar/calendar.dart
+++ b/tuberculosis/lib/calendar/calendar.dart
@@ -188,7 +188,7 @@ class CalendarState extends State<Calendar> {
     final mediaQuery = MediaQuery.of(context);
     return new Padding(
         child: new Column(children: [nameAndIconRow, calendarGridView]),
-        padding: mediaQuery.padding);
+        padding: new EdgeInsets.only(top: mediaQuery.padding.top));
   }
 
   void resetToToday() {

--- a/tuberculosis/lib/main.dart
+++ b/tuberculosis/lib/main.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-
 import 'package:Tubuddy/pages/pages.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
@@ -59,8 +58,12 @@ class _MyAppState extends State<MyApp> {
               TabPage pageContent;
               switch (index) {
                 case 0:
+                  List<MedicationItem> pills = dummyMedicationData;
+                  if (selectedDate.day != (new DateTime.now()).day) {
+                    pills = [new MedicationItem("Fissa", "Any Time", 1)];
+                  }
                   pageContent = new CalendarTabPage(
-                      selectedDate,
+                      selectedDate, pills,
                           (DateTime date) => setState(() {
                         selectedDate = date;
                       }));

--- a/tuberculosis/lib/main.dart
+++ b/tuberculosis/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:Tubuddy/pages/medication_tab_page.dart';
 import 'package:Tubuddy/pages/pages.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/cupertino.dart';
@@ -55,8 +56,12 @@ class _MyAppState extends State<MyApp> {
               TabPage pageContent;
               switch (index) {
                 case 0:
+                  List<MedicationItem> pills = dummyMedicationData;
+                  if (selectedDate.day != (new DateTime.now()).day) {
+                    pills = [new MedicationItem("Fissa", "Any Time", 1)];
+                  }
                   pageContent = new CalendarTabPage(
-                      selectedDate,
+                      selectedDate, pills,
                           (DateTime date) => setState(() {
                         selectedDate = date;
                       }));

--- a/tuberculosis/lib/pages/calendar_tab_page.dart
+++ b/tuberculosis/lib/pages/calendar_tab_page.dart
@@ -22,12 +22,14 @@ class CalendarTabPage extends StatelessWidget implements TabPage {
   Widget build(BuildContext context) {
     return new Column(children: <Widget>[
       Calendar(isExpandable: true, onDateSelected: onDateSelected),
-      Expanded(child: ListView.builder(
-          itemBuilder: (BuildContext context, int index) {
-            return pills[index];
-          },
-          itemCount: pills.length))
-    ]);
+      Divider(color: CupertinoColors.lightBackgroundGray, height: 5.0),
+      Expanded(
+          child: ListView(
+        children: pills,
+        shrinkWrap: false,
+        padding: EdgeInsets.zero,
+      ))
+    ], mainAxisSize: MainAxisSize.max);
   }
 
   @override

--- a/tuberculosis/lib/pages/calendar_tab_page.dart
+++ b/tuberculosis/lib/pages/calendar_tab_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:Tubuddy/pages/tab_page.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:Tubuddy/pages/medication_tab_page.dart';
 
 class CalendarTabPage extends StatelessWidget implements TabPage {
   static final title = const Text("Calendar");
@@ -13,12 +14,20 @@ class CalendarTabPage extends StatelessWidget implements TabPage {
 
   final DateTime today;
   final ValueChanged<DateTime> onDateSelected;
+  final List<MedicationItem> pills;
 
-  CalendarTabPage(this.today, [this.onDateSelected]);
+  CalendarTabPage(this.today, this.pills, [this.onDateSelected]);
 
   @override
   Widget build(BuildContext context) {
-    return new Calendar(isExpandable: true, onDateSelected: onDateSelected);
+    return new Column(children: <Widget>[
+      Calendar(isExpandable: true, onDateSelected: onDateSelected),
+      Expanded(child: ListView.builder(
+          itemBuilder: (BuildContext context, int index) {
+            return pills[index];
+          },
+          itemCount: pills.length))
+    ]);
   }
 
   @override


### PR DESCRIPTION
- Show the selected day's medication on the calendar page, right below
the calendar, separated by a light grey divider.

![image](https://user-images.githubusercontent.com/22079593/40372060-38f13ba0-5de4-11e8-84c7-84d4dad822b5.png)
