### PR TITLE
Add new FetchDataWidget with retry button implementation

### DIFF
--- a/tuberculosis/lib/api/fetch_data_widget.dart
+++ b/tuberculosis/lib/api/fetch_data_widget.dart
@@ -1,0 +1,52 @@
+import 'dart:async';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+typedef Widget FetchDataWidgetBuilder<T>(BuildContext context, T data);
+
+class FetchDataWidget<T> extends StatefulWidget {
+
+  final Function getFutureFunction;
+  final FetchDataWidgetBuilder<T> builder;
+
+  FetchDataWidget({this.getFutureFunction, this.builder});
+
+  @override
+  _FetchDataWidgetState<T> createState() => _FetchDataWidgetState<T>(getFutureFunction());
+}
+
+class _FetchDataWidgetState<T> extends State<FetchDataWidget<T>> {
+
+  Future<T> _future;
+
+  _FetchDataWidgetState(this._future);
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<T>(
+      future: _future,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.done) {
+          if (snapshot.hasError) {
+            return Center(
+                child: CupertinoButton(
+                  child: Text("Probeer opnieuw."),
+                  onPressed: () {
+                    setState(() {
+                      _future = widget.getFutureFunction();
+                    });
+                  },
+                )
+            );
+          } else {
+            return widget.builder(context, snapshot.data);
+          }
+        } else {
+          return Center(child: CircularProgressIndicator());
+        }
+      },
+    );
+  }
+
+}

--- a/tuberculosis/lib/pages/information_tab_page.dart
+++ b/tuberculosis/lib/pages/information_tab_page.dart
@@ -1,4 +1,5 @@
 import 'package:Tubuddy/api/api.dart';
+import 'package:Tubuddy/api/fetch_data_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:Tubuddy/pages/tab_page.dart';
@@ -12,24 +13,16 @@ class InformationTabPage extends StatelessWidget implements TabPage {
 
   @override
   Widget build(BuildContext context) {
-    return new FutureBuilder<List<String>>(
-      future: api.videos.getTopics(),
-      builder: (context, snapshot) {
-        if (snapshot.hasData) {
-          return new ListView.builder(
-            itemBuilder: (BuildContext context, int index) {
-              return new InfoEntryItem(new InfoEntry(snapshot.data[index]));
-            },
-            itemCount: snapshot.data.length,
-          );
-        }
-        else if (snapshot.hasError) {
-          return new Text("${snapshot.error}");
-        }
-        return new Center(
-          child: new CircularProgressIndicator()
+    return FetchDataWidget(
+      getFutureFunction: api.videos.getTopics,
+      builder: (context, data) {
+        return new ListView.builder(
+          itemBuilder: (BuildContext context, int index) {
+            return new InfoEntryItem(new InfoEntry(data[index]));
+          },
+          itemCount: data.length,
         );
-      },
+      }
     );
   }
 
@@ -74,25 +67,19 @@ class VideoSelectorScreen extends StatelessWidget {
         navigationBar: new CupertinoNavigationBar(
         middle: new Text(_topic),
       ),
-      child: new FutureBuilder<List<Video>>(
-        future: api.videos.getVideos(_topic),
-        builder: (context, snapshot) {
-          if (snapshot.hasData) {
-            return Material(child: ListView(children: snapshot.data.map((v) => ListTile(
-              title: Text(v.title),
-              onTap: () => Navigator.push(
-                  context,
-                  new CupertinoPageRoute(
-                      builder: (context) => VideoScreen(v)
-                  )
-              ),
-            )).toList(),));
-          } else if (snapshot.hasError) {
-            return Text("${snapshot.error}");
-          } else {
-            return Center(child: new CircularProgressIndicator(),);
-          }
-        }
+      child: FetchDataWidget<List<Video>>(
+        getFutureFunction: () => api.videos.getVideos(_topic),
+        builder: (context, data) {
+          return Material(child: ListView(children: data.map((v) => ListTile(
+            title: Text(v.title),
+            onTap: () => Navigator.push(
+                context,
+                new CupertinoPageRoute(
+                    builder: (context) => VideoScreen(v)
+                )
+            ),
+          )).toList(),));
+        },
       )
     );
   }


### PR DESCRIPTION
The FetchDataWidget widget abstract the futurebuilder such that a retry button will be added when the future results in an error.
Use this for all integration with the data api.